### PR TITLE
Relax gstreamer version requirements.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5759,7 +5759,7 @@ if test "$MOZ_GSTREAMER"; then
     # core/base release number
     # depend on >= 0.10.33 as that's when the playbin2 source-setup signal was
     # introduced
-    GST_VERSION=0.10.33
+    GST_VERSION=0.10.25
     PKG_CHECK_MODULES(GSTREAMER,
                       gstreamer-$GST_API_VERSION >= $GST_VERSION
                       gstreamer-app-$GST_API_VERSION

--- a/configure.in
+++ b/configure.in
@@ -5757,8 +5757,6 @@ if test "$MOZ_GSTREAMER"; then
     # API version, eg 0.10, 1.0 etc
     GST_API_VERSION=0.10
     # core/base release number
-    # depend on >= 0.10.33 as that's when the playbin2 source-setup signal was
-    # introduced
     GST_VERSION=0.10.25
     PKG_CHECK_MODULES(GSTREAMER,
                       gstreamer-$GST_API_VERSION >= $GST_VERSION

--- a/content/media/gstreamer/GStreamerReader.cpp
+++ b/content/media/gstreamer/GStreamerReader.cpp
@@ -88,6 +88,8 @@ GStreamerReader::~GStreamerReader()
 
   if (mPlayBin) {
     gst_app_src_end_of_stream(mSource);
+    if(mSource)
+      gst_object_unref(mSource);
     gst_element_set_state(mPlayBin, GST_STATE_NULL);
     gst_object_unref(mPlayBin);
     mPlayBin = NULL;
@@ -160,18 +162,21 @@ nsresult GStreamerReader::Init(MediaDecoderReader* aCloneDonor)
       "audio-sink", mAudioSink,
       NULL);
 
-  g_object_connect(mPlayBin, "signal::source-setup",
-      GStreamerReader::PlayBinSourceSetupCb, this, NULL);
-
+  g_signal_connect(G_OBJECT(mPlayBin), "notify::source",
+    G_CALLBACK(GStreamerReader::PlayBinSourceSetupCb), this);
+  
   return NS_OK;
 }
 
 void GStreamerReader::PlayBinSourceSetupCb(GstElement *aPlayBin,
-                                             GstElement *aSource,
+                                             GParamSpec *pspec,
                                              gpointer aUserData)
 {
+  GstElement *source;
   GStreamerReader *reader = reinterpret_cast<GStreamerReader*>(aUserData);
-  reader->PlayBinSourceSetup(GST_APP_SRC(aSource));
+
+  g_object_get(aPlayBin, "source", &source, NULL);
+  reader->PlayBinSourceSetup(GST_APP_SRC(source));
 }
 
 void GStreamerReader::PlayBinSourceSetup(GstAppSrc *aSource)

--- a/content/media/gstreamer/GStreamerReader.cpp
+++ b/content/media/gstreamer/GStreamerReader.cpp
@@ -88,7 +88,7 @@ GStreamerReader::~GStreamerReader()
 
   if (mPlayBin) {
     gst_app_src_end_of_stream(mSource);
-    if(mSource)
+    if (mSource)
       gst_object_unref(mSource);
     gst_element_set_state(mPlayBin, GST_STATE_NULL);
     gst_object_unref(mPlayBin);

--- a/content/media/gstreamer/GStreamerReader.h
+++ b/content/media/gstreamer/GStreamerReader.h
@@ -57,7 +57,7 @@ private:
    * configure appsrc .
    */
   static void PlayBinSourceSetupCb(GstElement *aPlayBin,
-                                   GstElement *aSource,
+                                   GParamSpec *pspec,
                                    gpointer aUserData);
   void PlayBinSourceSetup(GstAppSrc *aSource);
 

--- a/embedding/embedlite/config/mozconfig.qtN900-qt
+++ b/embedding/embedlite/config/mozconfig.qtN900-qt
@@ -36,9 +36,6 @@ ac_add_options --with-system-bz2
 ac_add_options --disable-elf-hack
 ac_add_options --disable-webrtc
 
-#disable for now, until VP8 gst codec is fast enough
-ac_add_options --disable-webm
-
 ac_add_options --with-gl-provider=EGL
 ac_add_options --enable-libjpeg-turbo
 

--- a/embedding/embedlite/config/mozconfig.qtN900-qt
+++ b/embedding/embedlite/config/mozconfig.qtN900-qt
@@ -1,0 +1,59 @@
+export ac_cv_have_usable_wchar_option_v2="no"
+ac_add_options --enable-application=mobile/xul
+#ac_add_options --enable-update-channel=nightly
+#ac_add_options --enable-update-packaging
+ac_add_options --enable-tests
+ac_add_options --enable-logging
+ac_add_options --enable-default-toolkit=cairo-qt
+ac_add_options --enable-mobile-optimize
+
+# required for meegotouch
+#ac_add_options --enable-cpp-rtti
+
+export MOZ_DEBUG_SYMBOLS=1
+ac_add_options --enable-debug-symbols="-ggdb"
+export MOZILLA_OFFICIAL=1
+mk_add_options PROFILE_GEN_SCRIPT=@TOPSRCDIR@/build/profile_pageloader.pl
+
+export CXXFLAGS="-mthumb -mfpu=neon -mtune=cortex-a8 -mcpu=cortex-a8 -DFORCE_BASICTILEDTHEBESLAYER=1 -DEGL_HAS_BACKING_SURFACE=1 -DUSE_ANDROID_OMTC_HACKS=1"
+# -DSQLITE_HAVE_ISNAN"
+export CFLAGS="-mthumb -mfpu=neon -mtune=cortex-a8 -mcpu=cortex-a8"
+# -DSQLITE_HAVE_ISNAN"
+
+#ac_add_options --enable-optimize="-O2 -ftree-vectorize -ffast-math"
+ac_add_options --disable-jemalloc
+ac_add_options --enable-gstreamer
+
+mk_add_options MOZ_MAKE_FLAGS="-j4"
+mk_add_options MOZ_OBJDIR="@TOPSRCDIR@/obj-build-n900-qt"
+ac_add_options --with-arm-kuser
+ac_add_options --with-thumb=yes
+ac_add_options --with-float-abi=toolchain-default
+
+ac_add_options --with-system-zlib
+ac_add_options --with-system-bz2
+
+ac_add_options --disable-elf-hack
+ac_add_options --disable-webrtc
+
+#disable for now, until VP8 gst codec is fast enough
+ac_add_options --disable-webm
+
+ac_add_options --with-gl-provider=EGL
+ac_add_options --enable-libjpeg-turbo
+
+ac_add_options --enable-tests
+ac_add_options --enable-profile-guided-optimization
+#ac_add_options --enable-valgrind
+#ac_add_options --enable-profiling
+
+ac_add_options --disable-accessibility
+ac_add_options --disable-crashreporter
+ac_add_options --disable-updater
+ac_add_options --disable-jsd
+ac_add_options --disable-printing
+
+#ac_add_options --enable-debug
+
+#fails to compile with this enabled, might raise a bug
+#ac_add_options --with-maemo-version=5


### PR DESCRIPTION
Use playbin2 "notify::source" signal instead of "signal::source-setup",
which is not available in gstreamer versions prior to 0.10.33.

Signed-off-by: Ivaylo Dimitrov freemangordon@abv.bg
