### PR TITLE
Relax gstreamer version requirements.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5757,9 +5757,7 @@ if test "$MOZ_GSTREAMER"; then
     # API version, eg 0.10, 1.0 etc
     GST_API_VERSION=0.10
     # core/base release number
-    # depend on >= 0.10.33 as that's when the playbin2 source-setup signal was
-    # introduced
-    GST_VERSION=0.10.33
+    GST_VERSION=0.10.25
     PKG_CHECK_MODULES(GSTREAMER,
                       gstreamer-$GST_API_VERSION >= $GST_VERSION
                       gstreamer-app-$GST_API_VERSION

--- a/content/media/gstreamer/GStreamerReader.cpp
+++ b/content/media/gstreamer/GStreamerReader.cpp
@@ -88,6 +88,8 @@ GStreamerReader::~GStreamerReader()
 
   if (mPlayBin) {
     gst_app_src_end_of_stream(mSource);
+    if (mSource)
+      gst_object_unref(mSource);
     gst_element_set_state(mPlayBin, GST_STATE_NULL);
     gst_object_unref(mPlayBin);
     mPlayBin = NULL;
@@ -160,18 +162,21 @@ nsresult GStreamerReader::Init(MediaDecoderReader* aCloneDonor)
       "audio-sink", mAudioSink,
       NULL);
 
-  g_object_connect(mPlayBin, "signal::source-setup",
-      GStreamerReader::PlayBinSourceSetupCb, this, NULL);
-
+  g_signal_connect(G_OBJECT(mPlayBin), "notify::source",
+    G_CALLBACK(GStreamerReader::PlayBinSourceSetupCb), this);
+  
   return NS_OK;
 }
 
 void GStreamerReader::PlayBinSourceSetupCb(GstElement *aPlayBin,
-                                             GstElement *aSource,
+                                             GParamSpec *pspec,
                                              gpointer aUserData)
 {
+  GstElement *source;
   GStreamerReader *reader = reinterpret_cast<GStreamerReader*>(aUserData);
-  reader->PlayBinSourceSetup(GST_APP_SRC(aSource));
+
+  g_object_get(aPlayBin, "source", &source, NULL);
+  reader->PlayBinSourceSetup(GST_APP_SRC(source));
 }
 
 void GStreamerReader::PlayBinSourceSetup(GstAppSrc *aSource)

--- a/content/media/gstreamer/GStreamerReader.h
+++ b/content/media/gstreamer/GStreamerReader.h
@@ -57,7 +57,7 @@ private:
    * configure appsrc .
    */
   static void PlayBinSourceSetupCb(GstElement *aPlayBin,
-                                   GstElement *aSource,
+                                   GParamSpec *pspec,
                                    gpointer aUserData);
   void PlayBinSourceSetup(GstAppSrc *aSource);
 


### PR DESCRIPTION
Use playbin2 "notify::source" signal instead of "signal::source-setup",
which is not available in gstreamer versions prior to 0.10.33.

Signed-off-by: Ivaylo Dimitrov freemangordon@abv.bg

Upstream bug https://bugzilla.mozilla.org/show_bug.cgi?id=836243
