### PR TITLE
Use glClear instead of fillRect to speed-up rendering when GL accelerate...

### DIFF
--- a/embedding/embedlite/tests/qt/qml/Makefile.in
+++ b/embedding/embedlite/tests/qt/qml/Makefile.in
@@ -48,6 +48,7 @@ LOCAL_INCLUDES	= -I$(srcdir) \
 LIBS += \
     $(TK_LIBS) \
     -lQtDeclarative \
+    -lGLESv2 \
     -lqjson \
     $(LIBXUL_DIST)/lib/$(LIB_PREFIX)qtembedwidget.$(LIB_SUFFIX) \
     $(NULL)

--- a/embedding/embedlite/tests/qt/qtwidget/qgraphicsmozview.cpp
+++ b/embedding/embedlite/tests/qt/qtwidget/qgraphicsmozview.cpp
@@ -278,6 +278,16 @@ QGraphicsMozView::onInitialized()
     d->mView = d->mContext->GetApp()->CreateView();
     d->mView->SetListener(d);
 }
+void QGraphicsMozView::EraseBackgroundGL(const QRect& r) {
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(r.x(), r.y(), r.width(), r.height());
+    glClearColor((GLfloat)d->mBgColor.red() / 255.0,
+                 (GLfloat)d->mBgColor.green() / 255.0, 
+                 (GLfloat)d->mBgColor.blue() / 255.0, 
+                 (GLfloat)d->mBgColor.alpha() / 255.0);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDisable(GL_SCISSOR_TEST);      
+}
 
 void
 QGraphicsMozView::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt, QWidget*)
@@ -294,12 +304,14 @@ QGraphicsMozView::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt, 
                 d->UpdateViewSize();
             }
             if (d->mLastIsGoodRotation) {
-                painter->fillRect(r, d->mBgColor);
+                QRect eraseRect = painter->transform().transposed().mapRect(r);
+
                 painter->beginNativePainting();
+                EraseBackgroundGL(eraseRect);
                 bool retval = d->mView->RenderGL();
                 painter->endNativePainting();
                 if (!retval) {
-                    painter->fillRect(r, d->mBgColor);
+                    EraseBackgroundGL(eraseRect);
                 }
             }
         } else {

--- a/embedding/embedlite/tests/qt/qtwidget/qgraphicsmozview.h
+++ b/embedding/embedlite/tests/qt/qtwidget/qgraphicsmozview.h
@@ -100,6 +100,7 @@ protected:
     virtual void keyReleaseEvent(QKeyEvent*);
     virtual void inputMethodEvent(QInputMethodEvent*);
     virtual QVariant inputMethodQuery(Qt::InputMethodQuery aQuery) const;
+    virtual void EraseBackgroundGL(const QRect&);
 
 private Q_SLOTS:
     void onInitialized();


### PR DESCRIPTION
...d

On N900 it raises fps from 16-17 to 22-23 when rendering http://romaxa.info/css3d/cube3d/cube_fast.html
