### PR TITLE
apzc: reset axis velocity if scroll direction was locked

### DIFF
--- a/gfx/layers/ipc/AsyncPanZoomController.h
+++ b/gfx/layers/ipc/AsyncPanZoomController.h
@@ -507,6 +507,10 @@ private:
    */
   void SetState(PanZoomState aState);
 
+/** Locks scrolling if velocity vector is close to an axis.
+ */
+  void LockScroll();
+
   nsRefPtr<CompositorParent> mCompositorParent;
   TaskThrottler mPaintThrottler;
   nsRefPtr<GeckoContentController> mGeckoContentController;


### PR DESCRIPTION
With this patch scroll locking works much closer to Harmattan browser. 
