### PR TITLE
Fix browser getting stuck in pinching mode

### DIFF
--- a/gfx/layers/ipc/GestureEventListener.cpp
+++ b/gfx/layers/ipc/GestureEventListener.cpp
@@ -260,7 +260,7 @@ nsEventStatus GestureEventListener::HandlePinchGestureEvent(const MultiTouchInpu
 
     mAsyncPanZoomController->HandleInputEvent(pinchEvent);
 
-    mState = GESTURE_NONE;
+    CancelGesture();
 
     rv = nsEventStatus_eConsumeNoDefault;
   }


### PR DESCRIPTION
This is a quick fix for the issue. Though it would be better to maintain GestureEventListener state in a more controlled way like with a private method SetState.
