### PR TITLE
Fix zoom limits when layout.css.devPixelsPerPx differs from 1.0

### DIFF
--- a/gfx/layers/ipc/Axis.cpp
+++ b/gfx/layers/ipc/Axis.cpp
@@ -361,7 +361,7 @@ bool Axis::ScaleWillOverscrollBothSides(float aScale) {
   CSSToScreenScale scale(metrics.mZoom.scale * aScale);
   CSSIntRect cssCompositionBounds = RoundedIn(metrics.mCompositionBounds / scale);
 
-  return GetRectLength(cssContentRect) < GetRectLength(CSSRect(cssCompositionBounds));
+  return GetRectLength(cssContentRect) < (GetRectLength(CSSRect(cssCompositionBounds)) / metrics.mDevPixelsPerCSSPixel.scale);
 }
 
 AxisX::AxisX(AsyncPanZoomController* aAsyncPanZoomController)


### PR DESCRIPTION
In those rare cases when layout.css.devPixelsPerPx differs from its
default value Gecko calculates zoom limits incorrectly making it impossible
to zoom out a viewport to fit device's screen.
