### PR TITLE
Handle pan end

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -249,6 +249,7 @@ EmbedLiteViewThreadParent::ActorDestroy(ActorDestroyReason aWhy)
   }
   if (mController) {
     mController->Destroy();
+    mController = nullptr;
   }
 }
 

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -24,6 +24,16 @@ using namespace mozilla::widget;
 namespace mozilla {
 namespace embedlite {
 
+/**
+ * Currently EmbedAsyncPanZoomController is needed because we need to do extra steps when panning ends.
+ * This is not optimal way to implement HandlePanEnd as AsyncPanZoomController
+ * invokes GeckoContentController::HandlePanEnd and overridden EmbedContentController::HandlePanEnd invokes
+ * a method of EmbedAsyncPanZoomController so that we can call protected methods of ASyncPanZoomController.
+ * There could be a virtual method that would allow us to do the same thing.
+ *
+ * Regardless of above, this helps us to keep AsyncPanZoomZontroller clean from
+ * embedlite specifc fixes.
+ */
 class EmbedAsyncPanZoomController : public AsyncPanZoomController
 {
   public:

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
@@ -18,6 +18,7 @@ namespace embedlite {
 class EmbedLiteView;
 class EmbedLiteCompositorParent;
 class EmbedContentController;
+class EmbedAsyncPanZoomController;
 class EmbedLiteViewThreadParent : public PEmbedLiteViewParent,
   public EmbedLiteViewImplIface
 {
@@ -147,7 +148,7 @@ private:
   gfx::Point mScrollOffset;
   float mLastScale;
 
-  RefPtr<mozilla::layers::AsyncPanZoomController> mController;
+  RefPtr<EmbedAsyncPanZoomController> mController;
   RefPtr<EmbedContentController> mGeckoController;
 
   gfxSize mViewSize;


### PR DESCRIPTION
This pull request overrides HandlePanEnd at EmbedContentController so that we know when panning ends. In addition, this pr adds EmbedAsyncPanZoomController so that we can call protected methods. Logic is not that nice but this way AsyncPanZoomController does not need changes. Thus, it ease up upstream merging.
