### PR TITLE
Turn EmbedLiteAppThreadParent singleton into EmbedLiteApp's exclusive attribute

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.h
+++ b/embedding/embedlite/EmbedLiteApp.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 #include <map>
 
+class MessageLoop;
+
 namespace mozilla {
 namespace embedlite {
 
@@ -139,11 +141,13 @@ private:
   friend class EmbedLiteViewThreadParent;
   friend class EmbedLiteCompositorParent;
   friend class EmbedLitePuppetWidget;
+
   EmbedLiteView* GetViewByID(uint32_t id);
   void ViewDestroyed(uint32_t id);
   void ChildReadyToDestroy();
   uint32_t CreateWindowRequested(const uint32_t& chromeFlags, const char* uri, const uint32_t& contextFlags, const uint32_t& parentId);
   EmbedLiteAppListener* GetListener();
+  MessageLoop* GetUILoop();
 
   static EmbedLiteApp* sSingleton;
   EmbedLiteAppListener* mListener;

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.cpp
@@ -11,7 +11,6 @@
 #include "EmbedLiteApp.h"
 
 #include "mozilla/unused.h"
-#include "EmbedLiteCompositorParent.h"
 
 using namespace base;
 using namespace mozilla::ipc;
@@ -21,18 +20,12 @@ namespace embedlite {
 
 static EmbedLiteAppThreadParent* sAppThreadParent = nullptr;
 
-EmbedLiteAppThreadParent*
-EmbedLiteAppThreadParent::GetInstance()
-{
-  return sAppThreadParent;
-}
-
-EmbedLiteAppThreadParent::EmbedLiteAppThreadParent(MessageLoop* aParentLoop)
+EmbedLiteAppThreadParent::EmbedLiteAppThreadParent()
   : mApp(EmbedLiteApp::GetInstance())
-  , mParentLoop(aParentLoop)
 {
   LOGT();
   MOZ_COUNT_CTOR(EmbedLiteAppThreadParent);
+  NS_ASSERTION(!sAppThreadParent, "Only one instance of EmbedLiteAppThreadParent is allowed");
   sAppThreadParent = this;
 }
 

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.h
@@ -16,7 +16,6 @@ class EmbedLiteAppThreadParent : public PEmbedLiteAppParent
 {
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(EmbedLiteAppThreadParent)
 public:
-  EmbedLiteAppThreadParent(MessageLoop* aParentLoop);
   virtual ~EmbedLiteAppThreadParent();
 
   virtual void SetBoolPref(const char* aName, bool aValue);
@@ -42,20 +41,18 @@ public:
           uint32_t* createdID,
           bool* cancel);
 
-  static EmbedLiteAppThreadParent* GetInstance();
-
-  MessageLoop* GetParentLoop() { return mParentLoop; }
-
 protected:
   virtual void ActorDestroy(ActorDestroyReason aWhy) MOZ_OVERRIDE;
   virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t&, const uint32_t&);
   virtual bool DeallocPEmbedLiteViewParent(PEmbedLiteViewParent*);
 
 private:
+  EmbedLiteAppThreadParent();
+
   EmbedLiteApp* mApp;
-  MessageLoop* mParentLoop;
 
 private:
+  friend class EmbedLiteApp;
   DISALLOW_EVIL_CONSTRUCTORS(EmbedLiteAppThreadParent);
 };
 

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -55,6 +55,8 @@ protected:
                                 nsIntPoint& aScrollOffset, float& aScaleX, float& aScaleY,
                                 gfx::Margin& aFixedLayerMargins);
 
+  void DeferredDestroyCompositor();
+
   bool IsGLBackend();
 
   RefPtr<EmbedLiteViewThreadParent> mView;


### PR DESCRIPTION
- Drop static method EmbedLiteAppThreadParent::GetInstance() as only EmbedLiteApp instance is allowed to create and to use EmbedLiteAppThreadParent singleton;
- Decouple EmbedLiteAppThreadParent from EmbedLiteCompositorParent;
- Drop EmbedLiteAppThreadParent::mParentLoop attribute, because EmbedLiteApp and EmbedLiteAppThreadParent live on the same thread and use the same message loop;
- Turn the static function DeferredDestroyCompositor() into private method EmbedLiteCompositorParent::DeferredDestroyCompositor().

WARNING: I couldn't fully test the last change because EmbedLiteCompositorParent instance never receives RecvStop() message.
