### PR TITLE
Update frame metrics / viewport when orientation changes

### DIFF
--- a/embedding/embedlite/embedthread/EmbedContentController.cpp
+++ b/embedding/embedlite/embedthread/EmbedContentController.cpp
@@ -30,7 +30,8 @@ void EmbedContentController::RequestContentRepaint(const FrameMetrics& aFrameMet
 {
     // We always need to post requests into the "UI thread" otherwise the
     // requests may get processed out of order.
-    LOGT();
+    LOG_FM(aFrameMetrics);
+
     mUILoop->PostTask(
         FROM_HERE,
         NewRunnableMethod(this, &EmbedContentController::DoRequestContentRepaint,

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -175,6 +175,7 @@ EmbedLiteViewThreadChild::InitGeckoWindow(const uint32_t& parentId)
   }
 
   rv = baseWindow->InitWindow(0, mWidget, 0, 0, mViewSize.width, mViewSize.height);
+  LOGT("window sz[%g, %g]", mViewSize.width, mViewSize.height);
   if (NS_FAILED(rv)) {
     return;
   }
@@ -492,14 +493,18 @@ bool
 EmbedLiteViewThreadChild::RecvSetViewSize(const gfxSize& aSize)
 {
   mViewResized = aSize != mViewSize;
+
+  LOGT("old sz[%g,%g], new sz[%g,%g], view resized: %d pointer: %p", mViewSize.width, mViewSize.height, aSize.width, aSize.height, mViewResized, this);
   mViewSize = aSize;
-  LOGT("sz[%g,%g]", mViewSize.width, mViewSize.height);
 
   if (!mWebBrowser) {
     return true;
   }
 
   mHelper->mInnerSize = ScreenIntSize::FromUnknownSize(gfx::IntSize(aSize.width, aSize.height));
+
+  LOGT("mInnerSize w:%d h:%d", mHelper->mInnerSize.width, mHelper->mInnerSize.height);
+
   nsCOMPtr<nsIBaseWindow> baseWindow = do_QueryInterface(mWebBrowser);
   baseWindow->SetPositionAndSize(0, 0, mViewSize.width, mViewSize.height, true);
   baseWindow->SetVisibility(true);
@@ -888,6 +893,7 @@ EmbedLiteViewThreadChild::OnFirstPaint(int32_t aX, int32_t aY)
     unused << SendSetBackgroundColor(bgcolor);
   }
 
+  LOGT("viewSize[%g,%g]", mViewSize.width, mViewSize.height);
   unused << RecvSetViewSize(mViewSize);
 
   return SendOnFirstPaint(aX, aY) ? NS_OK : NS_ERROR_FAILURE;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -914,7 +914,7 @@ EmbedLiteViewThreadChild::OnTitleChanged(const PRUnichar* aTitle)
 NS_IMETHODIMP
 EmbedLiteViewThreadChild::OnUpdateDisplayPort()
 {
-  LOGNI();
+  LOG_FM(mHelper->mFrameMetrics);
   return NS_OK;
 }
 

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -76,6 +76,7 @@ EmbedLiteViewThreadChild::EmbedLiteViewThreadChild(const uint32_t& aId, const ui
   : mId(aId)
   , mOuterId(0)
   , mViewSize(0, 0)
+  , mViewResized(false)
   , mDispatchSynthMouseEvents(true)
   , mIMEComposing(false)
 {
@@ -490,6 +491,7 @@ EmbedLiteViewThreadChild::RecvRemoveMessageListeners(const InfallibleTArray<nsSt
 bool
 EmbedLiteViewThreadChild::RecvSetViewSize(const gfxSize& aSize)
 {
+  mViewResized = aSize != mViewSize;
   mViewSize = aSize;
   LOGT("sz[%g,%g]", mViewSize.width, mViewSize.height);
 
@@ -572,13 +574,21 @@ EmbedLiteViewThreadChild::RecvUpdateFrame(const FrameMetrics& aFrameMetrics)
     return true;
   }
 
+
+  FrameMetrics metrics(aFrameMetrics);
+  if (mViewResized && mHelper->HandlePossibleViewportChange()) {
+    metrics = mHelper->mFrameMetrics;
+    mViewResized = false;
+  }
+
+
   for (unsigned int i = 0; i < mControllerListeners.Length(); i++) {
-    mControllerListeners[i]->RequestContentRepaint(aFrameMetrics);
+    mControllerListeners[i]->RequestContentRepaint(metrics);
   }
 
   bool ret = true;
   if (sHandleDefaultAZPC.viewport) {
-    ret = mHelper->RecvUpdateFrame(aFrameMetrics);
+    ret = mHelper->RecvUpdateFrame(metrics);
   }
 
   return ret;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
@@ -127,6 +127,7 @@ private:
   nsCOMPtr<nsIWebNavigation> mWebNavigation;
   WebBrowserChrome* mBChrome;
   gfxSize mViewSize;
+  bool mViewResized;
   gfxSize mGLViewSize;
 
   nsRefPtr<TabChildHelper> mHelper;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -226,7 +226,7 @@ bool
 EmbedLiteViewThreadParent::RecvOnScrolledAreaChanged(const uint32_t& aWidth,
                                                      const uint32_t& aHeight)
 {
-  LOGNI("area[%u,%u]", aWidth, aHeight);
+  LOGT("area[%u,%u]", aWidth, aHeight);
   if (mViewAPIDestroyed) {
     return true;
   }

--- a/embedding/embedlite/utils/EmbedLog.h
+++ b/embedding/embedlite/utils/EmbedLog.h
@@ -34,6 +34,21 @@ extern PRLogModuleInfo* GetEmbedCommonLog(const char* aModule);
 #endif // LOG_COMPONENT
 
 #define LOGC(CUSTOMNAME, FMT, ...) PR_LOG(GetEmbedCommonLog(CUSTOMNAME), PR_LOG_DEBUG, (CUSTOMNAME "::%s:%d " FMT , __FUNCTION__, __LINE__, ##__VA_ARGS__))
+#define LOG_FM(fm) LOGC("EmbedLiteViewPort", "i=(%ld %lld) " \
+         "cb=(%d %d %d %d) dp=(%.3f %.3f %.3f %.3f) v=(%.3f %.3f %.3f %.3f) " \
+         "s=(%.3f %.3f) sr=(%.3f %.3f %.3f %.3f) z=(%.3f %.3f %.3f %.3f)\n", \
+         fm.mPresShellId, fm.mScrollId, \
+         fm.mCompositionBounds.x, fm.mCompositionBounds.y, \
+         fm.mCompositionBounds.width, fm.mCompositionBounds.height, \
+         fm.mDisplayPort.x, fm.mDisplayPort.y, \
+         fm.mDisplayPort.width, fm.mDisplayPort.height, \
+         fm.mViewport.x, fm.mViewport.y, \
+         fm.mViewport.width, fm.mViewport.height, \
+         fm.mScrollOffset.x, fm.mScrollOffset.y, \
+         fm.mScrollableRect.x, fm.mScrollableRect.y, \
+         fm.mScrollableRect.width, fm.mScrollableRect.height, \
+         fm.mDevPixelsPerCSSPixel.scale, fm.mResolution.scale, \
+         fm.mCumulativeResolution.scale, fm.mZoom.scale)
 
 #else // EMBED_LITE_INTERNAL
 
@@ -54,6 +69,7 @@ extern PRLogModuleInfo* GetEmbedCommonLog(const char* aModule);
 #define LOGW(...) do {} while (0)
 #define LOGE(...) do {} while (0)
 #define LOGC(...) do {} while (0)
+#define LOG_FM(frameMetrics) do {} while (0)
 
 #endif // PR_LOGGING
 

--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -289,6 +289,7 @@ TabChildHelper::HandleEvent(nsIDOMEvent* aEvent)
 {
   nsAutoString eventType;
   aEvent->GetType(eventType);
+  // Should this also handle "MozScrolledAreaChanged".
   if (eventType.EqualsLiteral("DOMMetaAdded")) {
     // This meta data may or may not have been a meta viewport tag. If it was,
     // we should handle it immediately.
@@ -865,11 +866,11 @@ TabChildHelper::SetCSSViewport(const CSSSize& aSize)
   }
 }
 
-void
+bool
 TabChildHelper::HandlePossibleViewportChange()
 {
   if (sDisableViewportHandler) {
-    return;
+    return false;
   }
   nsCOMPtr<nsIDOMDocument> domDoc;
   mView->mWebNavigation->GetDocument(getter_AddRefs(domDoc));
@@ -878,9 +879,6 @@ TabChildHelper::HandlePossibleViewportChange()
   nsCOMPtr<nsIDOMWindowUtils> utils(GetDOMWindowUtils());
 
   nsViewportInfo viewportInfo = nsContentUtils::GetViewportInfo(document, mInnerSize);
-  mView->SendUpdateZoomConstraints(viewportInfo.IsZoomAllowed(),
-                                   viewportInfo.GetMinZoom().scale,
-                                   viewportInfo.GetMaxZoom().scale);
 
   float screenW = mInnerSize.width;
   float screenH = mInnerSize.height;
@@ -889,7 +887,7 @@ TabChildHelper::HandlePossibleViewportChange()
   // We're not being displayed in any way; don't bother doing anything because
   // that will just confuse future adjustments.
   if (!screenW || !screenH) {
-    return;
+    return false;
   }
 
   // Make sure the viewport height is not shorter than the window when the page
@@ -914,7 +912,7 @@ TabChildHelper::HandlePossibleViewportChange()
   // window.innerWidth before they are painted have a correct value (bug
   // 771575).
   if (!mContentDocumentIsDisplayed) {
-    return;
+    return false;
   }
 
   nsPresContext* presContext = GetPresContext();
@@ -948,12 +946,18 @@ TabChildHelper::HandlePossibleViewportChange()
   }
   if (!pageSize.width) {
     // Return early rather than divide by 0.
-    return;
+    return false;
   }
 
   CSSToScreenScale minScale(mInnerSize.width / pageSize.width);
   minScale = clamped(minScale, viewportInfo.GetMinZoom(), viewportInfo.GetMaxZoom());
-  NS_ENSURE_TRUE_VOID(minScale.scale); // (return early rather than divide by 0)
+  NS_ENSURE_TRUE(minScale.scale, false); // (return early rather than divide by 0)
+
+  // Update zoom contraints with clamped minimum scale so that zooming below page width is not possible.
+  mView->SendUpdateZoomConstraints(viewportInfo.IsZoomAllowed(),
+                                   minScale.scale,
+                                   viewportInfo.GetMaxZoom().scale);
+
 
   viewport.height = std::max(viewport.height, screenH / minScale.scale);
   SetCSSViewport(viewport);
@@ -1011,9 +1015,14 @@ TabChildHelper::HandlePossibleViewportChange()
   // This is the root layer, so the cumulative resolution is the same
   // as the resolution.
   metrics.mResolution = metrics.mCumulativeResolution / LayoutDeviceToParentLayerScale(1);
+
+  LOGC("EmbedLiteViewPort", "metrics cumulative reso %g mReso %g", metrics.mCumulativeResolution.scale, metrics.mResolution.scale);
+
   utils->SetResolution(metrics.mResolution.scale, metrics.mResolution.scale);
 
   // Force a repaint with these metrics. This, among other things, sets the
   // displayport, so we start with async painting.
   ProcessUpdateFrame(metrics);
+  mFrameMetrics = metrics;
+  return true;
 }

--- a/embedding/embedlite/utils/TabChildHelper.h
+++ b/embedding/embedlite/utils/TabChildHelper.h
@@ -94,7 +94,7 @@ private:
   // viewport data on a document may have changed. If it didn't
   // change, this function doesn't do anything.  However, it should
   // not be called all the time as it is fairly expensive.
-  void HandlePossibleViewportChange();
+  bool HandlePossibleViewportChange();
 
   friend class EmbedLiteViewThreadChild;
   EmbedLiteViewThreadChild* mView;
@@ -103,6 +103,7 @@ private:
   float mOldViewportWidth;
   nsRefPtr<EmbedTabChildGlobal> mTabChildGlobal;
   mozilla::layers::FrameMetrics mLastMetrics;
+  mozilla::layers::FrameMetrics mFrameMetrics;
 };
 
 }

--- a/gfx/layers/ipc/AsyncPanZoomController.cpp
+++ b/gfx/layers/ipc/AsyncPanZoomController.cpp
@@ -755,6 +755,7 @@ nsEventStatus AsyncPanZoomController::OnScale(const PinchGestureInput& aEvent) {
         ScrollBy(neededDisplacement);
       }
 
+      APZC_LOG("%p OnScale about to schedule composite on state=%d scale=%.3f\n", this, mState, mFrameMetrics.mZoom.scale);
       ScheduleComposite();
       // We don't want to redraw on every scale, so don't use
       // RequestContentRepaint()
@@ -1453,7 +1454,8 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
 
   bool isDefault = mFrameMetrics.IsDefault();
   mFrameMetrics.mMayHaveTouchListeners = aLayerMetrics.mMayHaveTouchListeners;
-  APZC_LOG_FM(aLayerMetrics, "%p got a NotifyLayersUpdated with aIsFirstPaint=%d", this, aIsFirstPaint);
+  APZC_LOG_FM(aLayerMetrics, "%p got a NotifyLayersUpdated with aIsFirstPaint=%d aIsDefault=%d", this, aIsFirstPaint, isDefault);
+  APZC_LOG_FM(mFrameMetrics, "%p got a NotifyLayersUpdated current mFrameMetrics", this);
 
   LogRendertraceRect("page", "brown", aLayerMetrics.mScrollableRect);
   LogRendertraceRect("painted displayport", "green",
@@ -1482,6 +1484,7 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
 
     mFrameMetrics = aLayerMetrics;
     SetState(NOTHING);
+    APZC_LOG_FM(mFrameMetrics, "%p NotifyLayersUpdated cleanup frame metrics needContentRepaint=%d\n", this, needContentRepaint);
   } else {
     // If we're not taking the aLayerMetrics wholesale we still need to pull
     // in some things into our local mFrameMetrics because these things are
@@ -1498,6 +1501,7 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
     }
     mFrameMetrics.mResolution = aLayerMetrics.mResolution;
     mFrameMetrics.mCumulativeResolution = aLayerMetrics.mCumulativeResolution;
+    APZC_LOG_FM(mFrameMetrics, "%p NotifyLayersUpdated copy some things into local framemetrics, needContentRepaint=%d\n", this, needContentRepaint);
   }
 
   if (needContentRepaint) {

--- a/gfx/layers/ipc/AsyncPanZoomController.cpp
+++ b/gfx/layers/ipc/AsyncPanZoomController.cpp
@@ -1465,8 +1465,11 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
       aLayerMetrics.mCompositionBounds.height == mFrameMetrics.mCompositionBounds.height) {
     // Remote content has sync'd up to the composition geometry
     // change, so we can accept the viewport it's calculated.
-    if (mFrameMetrics.mViewport.width != aLayerMetrics.mViewport.width)
+    if (mFrameMetrics.mViewport.width != aLayerMetrics.mViewport.width) {
+      mFrameMetrics.mDisplayPort = aLayerMetrics.mDisplayPort;
       needContentRepaint = true;
+    }
+
     mFrameMetrics.mViewport = aLayerMetrics.mViewport;
   }
 
@@ -1487,7 +1490,12 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
     mFrameMetrics.mCompositionBounds = aLayerMetrics.mCompositionBounds;
     float parentResolutionChange = aLayerMetrics.GetParentResolution().scale
                                  / mFrameMetrics.GetParentResolution().scale;
-    mFrameMetrics.mZoom.scale *= parentResolutionChange;
+    // Geometry changed. Need to keep mZoom level of previous geometry.
+    if (needContentRepaint) {
+        mFrameMetrics.mZoom.scale = aLayerMetrics.mZoom.scale;
+    } else {
+        mFrameMetrics.mZoom.scale *= parentResolutionChange;
+    }
     mFrameMetrics.mResolution = aLayerMetrics.mResolution;
     mFrameMetrics.mCumulativeResolution = aLayerMetrics.mCumulativeResolution;
   }


### PR DESCRIPTION
Sending zoom contraints update from TabChildHelper is delayed
until new target viewport size is calculated. The new target
viewport size is used for calculating minimum viewport size.

AsyncPanZoomController also resets displayPort
when composition bounds have changed.

Viewport related logs added behind "EmbedLiteViewPort" logging component.
