### PR TITLE
Update frame metrics / viewport when orientation changes

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
@@ -127,6 +127,7 @@ private:
   nsCOMPtr<nsIWebNavigation> mWebNavigation;
   WebBrowserChrome* mBChrome;
   gfxSize mViewSize;
+  bool mViewResized;
   gfxSize mGLViewSize;
 
   nsRefPtr<TabChildHelper> mHelper;

--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -293,6 +293,7 @@ TabChildHelper::HandleEvent(nsIDOMEvent* aEvent)
 {
   nsAutoString eventType;
   aEvent->GetType(eventType);
+  // Should this also handle "MozScrolledAreaChanged".
   if (eventType.EqualsLiteral("DOMMetaAdded")) {
     // This meta data may or may not have been a meta viewport tag. If it was,
     // we should handle it immediately.
@@ -891,11 +892,11 @@ TabChildHelper::SetCSSViewport(const CSSSize& aSize)
   }
 }
 
-void
+bool
 TabChildHelper::HandlePossibleViewportChange()
 {
   if (sDisableViewportHandler) {
-    return;
+    return false;
   }
   nsCOMPtr<nsIDOMDocument> domDoc;
   mView->mWebNavigation->GetDocument(getter_AddRefs(domDoc));
@@ -904,9 +905,6 @@ TabChildHelper::HandlePossibleViewportChange()
   nsCOMPtr<nsIDOMWindowUtils> utils(GetDOMWindowUtils());
 
   nsViewportInfo viewportInfo = nsContentUtils::GetViewportInfo(document, mInnerSize);
-  mView->SendUpdateZoomConstraints(viewportInfo.IsZoomAllowed(),
-                                   viewportInfo.GetMinZoom().scale,
-                                   viewportInfo.GetMaxZoom().scale);
 
   float screenW = mInnerSize.width;
   float screenH = mInnerSize.height;
@@ -915,7 +913,7 @@ TabChildHelper::HandlePossibleViewportChange()
   // We're not being displayed in any way; don't bother doing anything because
   // that will just confuse future adjustments.
   if (!screenW || !screenH) {
-    return;
+    return false;
   }
 
   // Make sure the viewport height is not shorter than the window when the page
@@ -940,7 +938,7 @@ TabChildHelper::HandlePossibleViewportChange()
   // window.innerWidth before they are painted have a correct value (bug
   // 771575).
   if (!mContentDocumentIsDisplayed) {
-    return;
+    return false;
   }
 
   nsPresContext* presContext = GetPresContext();
@@ -974,12 +972,18 @@ TabChildHelper::HandlePossibleViewportChange()
   }
   if (!pageSize.width) {
     // Return early rather than divide by 0.
-    return;
+    return false;
   }
 
   CSSToScreenScale minScale(mInnerSize.width / pageSize.width);
   minScale = clamped(minScale, viewportInfo.GetMinZoom(), viewportInfo.GetMaxZoom());
-  NS_ENSURE_TRUE_VOID(minScale.scale); // (return early rather than divide by 0)
+  NS_ENSURE_TRUE(minScale.scale, false); // (return early rather than divide by 0)
+
+  // Update zoom contraints with clamped minimum scale so that zooming below page width is not possible.
+  mView->SendUpdateZoomConstraints(viewportInfo.IsZoomAllowed(),
+                                   minScale.scale,
+                                   viewportInfo.GetMaxZoom().scale);
+
 
   viewport.height = std::max(viewport.height, screenH / minScale.scale);
   SetCSSViewport(viewport);
@@ -1037,9 +1041,14 @@ TabChildHelper::HandlePossibleViewportChange()
   // This is the root layer, so the cumulative resolution is the same
   // as the resolution.
   metrics.mResolution = metrics.mCumulativeResolution / LayoutDeviceToParentLayerScale(1);
+
+  LOGC("EmbedLiteViewPort", "metrics cumulative reso %g mReso %g", metrics.mCumulativeResolution.scale, metrics.mResolution.scale);
+
   utils->SetResolution(metrics.mResolution.scale, metrics.mResolution.scale);
 
   // Force a repaint with these metrics. This, among other things, sets the
   // displayport, so we start with async painting.
   ProcessUpdateFrame(metrics);
+  mFrameMetrics = metrics;
+  return true;
 }

--- a/embedding/embedlite/utils/TabChildHelper.h
+++ b/embedding/embedlite/utils/TabChildHelper.h
@@ -94,7 +94,7 @@ private:
   // viewport data on a document may have changed. If it didn't
   // change, this function doesn't do anything.  However, it should
   // not be called all the time as it is fairly expensive.
-  void HandlePossibleViewportChange();
+  bool HandlePossibleViewportChange();
 
   friend class EmbedLiteViewThreadChild;
   EmbedLiteViewThreadChild* mView;
@@ -103,6 +103,7 @@ private:
   float mOldViewportWidth;
   nsRefPtr<EmbedTabChildGlobal> mTabChildGlobal;
   mozilla::layers::FrameMetrics mLastMetrics;
+  mozilla::layers::FrameMetrics mFrameMetrics;
 };
 
 }

--- a/gfx/layers/ipc/AsyncPanZoomController.cpp
+++ b/gfx/layers/ipc/AsyncPanZoomController.cpp
@@ -1194,7 +1194,11 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
     CSSToScreenScale previousResolution = mFrameMetrics.CalculateIntrinsicScale();
     mFrameMetrics.mViewport = aLayerMetrics.mViewport;
     CSSToScreenScale newResolution = mFrameMetrics.CalculateIntrinsicScale();
-    if (previousResolution != newResolution) {
+    if (mFrameMetrics.mViewport.width != aLayerMetrics.mViewport.width) {
+      mFrameMetrics.mDisplayPort = aLayerMetrics.mDisplayPort;
+      mFrameMetrics.mZoom.scale = aLayerMetrics.mZoom.scale;
+      needContentRepaint = true;
+    } else if (previousResolution != newResolution) {
       needContentRepaint = true;
       mFrameMetrics.mZoom.scale *= newResolution.scale / previousResolution.scale;
     }
@@ -1211,6 +1215,9 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
     mState = NOTHING;
   } else if (!mFrameMetrics.mScrollableRect.IsEqualEdges(aLayerMetrics.mScrollableRect)) {
     mFrameMetrics.mScrollableRect = aLayerMetrics.mScrollableRect;
+    mFrameMetrics.mCompositionBounds = aLayerMetrics.mCompositionBounds;
+    mFrameMetrics.mResolution = aLayerMetrics.mResolution;
+    mFrameMetrics.mCumulativeResolution = aLayerMetrics.mCumulativeResolution;
   }
 
   if (needContentRepaint) {

--- a/gfx/layers/ipc/AsyncPanZoomController.cpp
+++ b/gfx/layers/ipc/AsyncPanZoomController.cpp
@@ -52,6 +52,22 @@
 #include "nsThreadUtils.h"              // for NS_IsMainThread
 #include "nsTraceRefcnt.h"              // for MOZ_COUNT_CTOR, etc
 
+
+#define APZC_LOG(...)
+// #define APZC_LOG(...) printf_stderr("APZC: " __VA_ARGS__)
+#define APZC_LOG_FM(fm, prefix, ...) \
+  APZC_LOG(prefix ":" \
+           " i=(%ld %lld) cb=(%d %d %d %d) dp=(%.3f %.3f %.3f %.3f) v=(%.3f %.3f %.3f %.3f) " \
+           "s=(%.3f %.3f) sr=(%.3f %.3f %.3f %.3f) z=(%.3f %.3f %.3f %.3f)\n", \
+           __VA_ARGS__, \
+           fm.mPresShellId, fm.mScrollId, \
+           fm.mCompositionBounds.x, fm.mCompositionBounds.y, fm.mCompositionBounds.width, fm.mCompositionBounds.height, \
+           fm.mDisplayPort.x, fm.mDisplayPort.y, fm.mDisplayPort.width, fm.mDisplayPort.height, \
+           fm.mViewport.x, fm.mViewport.y, fm.mViewport.width, fm.mViewport.height, \
+           fm.mScrollOffset.x, fm.mScrollOffset.y, \
+           fm.mScrollableRect.x, fm.mScrollableRect.y, fm.mScrollableRect.width, fm.mScrollableRect.height, \
+           fm.mDevPixelsPerCSSPixel.scale, fm.mResolution.scale, fm.mCumulativeResolution.scale, fm.mZoom.scale); \
+
 using namespace mozilla::css;
 
 namespace mozilla {
@@ -1180,6 +1196,9 @@ ViewTransform AsyncPanZoomController::GetCurrentAsyncTransform() {
 void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetrics, bool aIsFirstPaint) {
   ReentrantMonitorAutoEnter lock(mMonitor);
 
+  APZC_LOG_FM(aLayerMetrics, "%p got a NotifyLayersUpdated with aIsFirstPaint=%d aIsDefault=%d", this, aIsFirstPaint, isDefault);
+  APZC_LOG_FM(mFrameMetrics, "%p got a NotifyLayersUpdated current mFrameMetrics", this);
+
   mLastContentPaintMetrics = aLayerMetrics;
 
   bool isDefault = mFrameMetrics.IsDefault();
@@ -1218,6 +1237,7 @@ void AsyncPanZoomController::NotifyLayersUpdated(const FrameMetrics& aLayerMetri
     mFrameMetrics.mCompositionBounds = aLayerMetrics.mCompositionBounds;
     mFrameMetrics.mResolution = aLayerMetrics.mResolution;
     mFrameMetrics.mCumulativeResolution = aLayerMetrics.mCumulativeResolution;
+    APZC_LOG_FM(mFrameMetrics, "%p NotifyLayersUpdated copy some things into local framemetrics, needContentRepaint=%d\n", this, needContentRepaint);
   }
 
   if (needContentRepaint) {


### PR DESCRIPTION
Rebased functional changed from
https://github.com/tmeshkova/mozilla-central/pull/48

Namely commit: https://github.com/rainemak/mozilla-central/commit/08794bf7831f94a47c6b859a634feec0c844e64d

Some changes needed to be for apzc as there were diff between 29 and 26 engines.

In addition, some apzc logs ported (in another commit).
